### PR TITLE
added .db extension

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -75,6 +75,7 @@
 				<string>TEXT</string>
 				<key>public.filename-extension</key>
 				<array>
+					<string>db</string>
 					<string>sqlite</string>
 				</array>
 			</dict>


### PR DESCRIPTION
The plugin now recognizes  ".db" files as sqlite databases.
